### PR TITLE
Spelling fixes for Ballyhoo

### DIFF
--- a/outside.zil
+++ b/outside.zil
@@ -4815,7 +4815,7 @@ tobacco." CR>)
 	       (<AND <VERB? COMPARE>
 		     <EQUAL? ,NOTE ,PRSO ,PRSI>>
 		<TELL 
-"The \"M\" on the " D ,SCRAP " looks like it was cut from the the same
+"The \"M\" on the " D ,SCRAP " looks like it was cut from the same
 newspaper as the letters on the " D ,NOTE "." CR>)  
 	       (<VERB? READ>
 		<TELL 

--- a/parser.zil
+++ b/parser.zil
@@ -1377,7 +1377,7 @@ OOPS-INBUF, leaving the appropriate pointers in AGAIN-LEXV"
 			     (T
 			      <SETG CURSED-ONCE? T>
 			      <TELL
-"Bravisimo! Once more now, with feeling." CR>)>)
+"Bravissimo! Once more now, with feeling." CR>)>)
 		      (<G? ,CURSE-C 4>
 		       <SETG CURSE-C 0>
 		       <DISABLE <INT I-CURSE>>


### PR DESCRIPTION
These are the spelling fixes for Ballyhoo from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.